### PR TITLE
Add 'alias' (IMDb lookup) endpoint

### DIFF
--- a/lib/endpoints.json
+++ b/lib/endpoints.json
@@ -5,7 +5,8 @@
 			"search": {"resource": "movies.json", "type": "get" },
 			"get": {"resource": "movies/:id.json", "type": "get" },
 			"reviews": {"resource": "movies/:id/reviews.json", "type": "get" },
-			"clips": {"resource": "movies/:id/clips.json", "type": "get" }
+			"clips": {"resource": "movies/:id/clips.json", "type": "get" },
+			"alias": {"resource": "movie_alias.json", "type": "get" }
 		},
 		"listMovies": {
 			"boxOffice": {"resource": "lists/movies/box_office.json", "type": "get"},


### PR DESCRIPTION
Rotten Tomatoes allows for lookups by IMDb ID, so I went ahead and added that line to the available endpoints. 

It's a little quirky: `id` needs to be numeric (so strip the first two letters) and `type` should be set to 'imdb' (and there are no other options, currently). Here's a rough example:

`rt.movieAlias({ id: 'tt0051189'.substring(2), type: 'imdb' }, function(err, res){ /* etc */ });`
